### PR TITLE
isomorphic support

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function useNative () {
 module.exports = useNative() ? NativeCustomEvent :
 
 // IE >= 9
-'function' === typeof document.createEvent ? function CustomEvent (type, params) {
+'undefined' !== typeof document && 'function' === typeof document.createEvent ? function CustomEvent (type, params) {
   var e = document.createEvent('CustomEvent');
   if (params) {
     e.initCustomEvent(type, params.bubbles, params.cancelable, params.detail);


### PR DESCRIPTION
when requiring this module on an isomorphic app, it throws:

```
/whatever/node_modules/crossvent/node_modules/custom-event/index.js:24
'function' === typeof document.createEvent ? function CustomEvent (type, params) {
                      ^

ReferenceError: document is not defined
```

so this is an attemp to solve that
